### PR TITLE
Added speed optimized version of the JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="integer-universe.js"></script>
+    <script src="optimal-universe.js"></script>
   </head>
   <body>
     <canvas id="canvas"></canvas>

--- a/optimal-universe.js
+++ b/optimal-universe.js
@@ -1,0 +1,53 @@
+var canvas;
+var context;
+var size, offsetx, offsety;
+var u = 0.0, v = 0.0, x = 0.0, t = 0.0;
+
+function update() {
+    context.fillStyle = "rgba(0,0,0,0.5)";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    const n = 200, r = 2 * Math.PI / 235;
+    let lastColor;
+    context.beginPath();
+
+    for (let i = 0; i < n; i++) {
+        for (let j = 0; j < n; j++) {
+            const sin_i_v = Math.sin(i + v);
+            const cos_i_v = Math.cos(i + v);
+            u = sin_i_v + Math.sin(r * i + x);
+            v = cos_i_v + Math.cos(r * i + x);
+            x = u + t;
+
+            const currentColor = `rgba(${i},${j},99,1.0)`;
+            if (currentColor !== lastColor) {
+                context.fillStyle = currentColor;
+                lastColor = currentColor;
+            }
+
+            context.fillRect(offsetx + size * u - 1, offsety + size * v - 1, 3, 3);
+        }
+    }
+
+    t += 0.025;
+
+    requestAnimationFrame(update);
+}
+
+window.onload = function () {
+    document.body.style = "margin:0; padding:0;";
+    canvas = document.getElementById("canvas");
+    canvas.style.filter = "blur(1px)";
+    canvas.width = document.documentElement.clientWidth;
+    canvas.height = document.documentElement.clientHeight;
+    offsetx = canvas.width / 2;
+    offsety = canvas.height / 2;
+
+    size = (canvas.width > canvas.height ? canvas.height : canvas.width) * 0.225;
+
+    if (canvas.getContext) {
+        context = canvas.getContext("2d");
+        requestAnimationFrame(update);
+    }
+}
+


### PR DESCRIPTION
Batch Drawing Operations: Instead of setting the fillStyle and drawing a rectangle for every iteration of the loop, we use the beginPath and moveTo functions to draw all rectangles in one go, changing the color only when it's different from the previous iteration.

Avoid Redundant Computations: We cache some of the redundant computations outside the loop.

Use requestAnimationFrame: It's more efficient than setInterval for animations.